### PR TITLE
Fix full-width bitfield access

### DIFF
--- a/bitfield.hpp
+++ b/bitfield.hpp
@@ -3,7 +3,7 @@
  * Copyright 2023. Derek (Daax) Rynd.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the ìSoftwareî), to deal
+ * of this software and associated documentation files (the ‚ÄúSoftware‚Äù), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
@@ -12,7 +12,7 @@
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
  *
- * THE SOFTWARE IS PROVIDED ìAS ISî, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * THE SOFTWARE IS PROVIDED ‚ÄúAS IS‚Äù, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
@@ -117,7 +117,7 @@ struct bitfield
 
             // If trying to shift full-width of type, behavior is undefined... condition above added.
             //
-            return static_cast< AsType >( ( data_ref >> start_position ) & ( ( T( 1 ) << len ) - 1 ) );
+            return static_cast< AsType >( ( data_ref >> start_position ) & ( ( AsType( 1 ) << len ) - 1 ) );
         }
 
         private:


### PR DESCRIPTION
Fix bitfield::as to correctly work on example code.

The changes in license were automatically added by GitHub web editor as it changed the file to utf8